### PR TITLE
Feature: support apple silicon

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,9 +2,20 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 import librosa
+import torch
 import panns_inference
 from panns_inference import AudioTagging, SoundEventDetection, labels
 
+
+def get_preferred_device():
+    try:
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available() and getattr(torch.backends.mps, "is_built", lambda: True)():
+            return "mps"
+    except Exception:
+        pass
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
 
 def print_audio_tagging_result(clipwise_output):
     """Visualization of audio tagging result.
@@ -51,7 +62,8 @@ def plot_sound_event_detection_result(framewise_output):
 if __name__ == '__main__':
     """Example of using panns_inferece for audio tagging and sound evetn detection.
     """
-    device = 'cpu' # 'cuda' | 'cpu'
+    device = get_preferred_device()  # 'mps' | 'cuda' | 'cpu'
+    print('Using device: {}'.format(device))
     audio_path = 'resources/R9_ZSCveAHg_7s.wav'
     (audio, _) = librosa.core.load(audio_path, sr=32000, mono=True)
     audio = audio[None, :]  # (batch_size, segment_samples)


### PR DESCRIPTION
These changes add support for Apple Silicon (MPS) to the methods in inference.py
I have also added a method to automatically obtain the preferred device (cuda | mps | cpu) in example.py

Significant performance increase (opposed to 'cpu') has been confirmed when testing on longer audio files than the included one, probably due to the included file being so short that the majority of execution time is spent on initialising the process, not on the actual inference. Tested on Macbook with M2 Pro processor.